### PR TITLE
Updated cvars header include directory.

### DIFF
--- a/src/vicalib-task.cc
+++ b/src/vicalib-task.cc
@@ -2,7 +2,7 @@
 
 #include <time.h>
 #include <random>
-#include <CVars/CVar.h>
+#include <cvars/CVar.h>
 #include <calibu/conics/ConicFinder.h>
 #include <calibu/pose/Pnp.h>
 #include <HAL/Messages/Matrix.h>


### PR DESCRIPTION
"CVars" include directory was recently changed to "cvars." Updating the include in the source file to reflect the change.